### PR TITLE
refacto: move consumer logic to abstract consumer

### DIFF
--- a/bizon/engine/pipeline/consumer.py
+++ b/bizon/engine/pipeline/consumer.py
@@ -1,12 +1,16 @@
 import multiprocessing
 import multiprocessing.synchronize
 import threading
+import traceback
 from abc import ABC, abstractmethod
 from typing import Union
 
+from loguru import logger
+
 from bizon.destination.destination import AbstractDestination
 from bizon.engine.pipeline.models import PipelineReturnStatus
-from bizon.engine.queue.config import AbstractQueueConfig
+from bizon.engine.queue.config import AbstractQueueConfig, QueueMessage
+from bizon.engine.queue.config import QUEUE_TERMINATION
 from bizon.transform.transform import Transform
 
 
@@ -19,3 +23,46 @@ class AbstractQueueConsumer(ABC):
     @abstractmethod
     def run(self, stop_event: Union[multiprocessing.synchronize.Event, threading.Event]) -> PipelineReturnStatus:
         pass
+
+    def process_queue_message(self, queue_message: QueueMessage) -> PipelineReturnStatus:
+
+        # Apply the transformation
+        try:
+            df_source_records = self.transform.apply_transforms(df_source_records=queue_message.df_source_records)
+        except Exception as e:
+            logger.error(f"Error applying transformation: {e}")
+            logger.error(traceback.format_exc())
+            return PipelineReturnStatus.TRANSFORM_ERROR
+
+        # Handle last iteration
+        try:
+            if queue_message.signal == QUEUE_TERMINATION:
+                logger.info("Received termination signal, waiting for destination to close gracefully ...")
+                self.destination.write_records_and_update_cursor(
+                    df_source_records=df_source_records,
+                    iteration=queue_message.iteration,
+                    extracted_at=queue_message.extracted_at,
+                    pagination=queue_message.pagination,
+                    last_iteration=True,
+                )
+                return PipelineReturnStatus.SUCCESS
+
+        except Exception as e:
+            logger.error(f"Error writing records to destination: {e}")
+            return PipelineReturnStatus.DESTINATION_ERROR
+
+        # Write the records to the destination
+        try:
+            self.destination.write_records_and_update_cursor(
+                df_source_records=df_source_records,
+                iteration=queue_message.iteration,
+                extracted_at=queue_message.extracted_at,
+                pagination=queue_message.pagination,
+            )
+            return PipelineReturnStatus.RUNNING
+
+        except Exception as e:
+            logger.error(f"Error writing records to destination: {e}")
+            return PipelineReturnStatus.DESTINATION_ERROR
+
+        raise RuntimeError("Should not reach this point")

--- a/bizon/engine/pipeline/models.py
+++ b/bizon/engine/pipeline/models.py
@@ -4,11 +4,11 @@ from enum import Enum
 class PipelineReturnStatus(str, Enum):
     """Producer error types"""
 
-    SUCCESS = "success"
-    ERROR = "error"
+    BACKEND_ERROR = "backend_error"
+    DESTINATION_ERROR = "destination_error"
     KILLED_BY_RUNNER = "killed_by_runner"
     QUEUE_ERROR = "queue_error"
+    RUNNING = "running"
     SOURCE_ERROR = "source_error"
-    BACKEND_ERROR = "backend_error"
+    SUCCESS = "success"
     TRANSFORM_ERROR = "transform_error"
-    DESTINATION_ERROR = "destination_error"

--- a/bizon/engine/queue/adapters/kafka/consumer.py
+++ b/bizon/engine/queue/adapters/kafka/consumer.py
@@ -5,7 +5,7 @@ from loguru import logger
 
 from bizon.destination.destination import AbstractDestination
 from bizon.engine.pipeline.consumer import AbstractQueueConsumer
-from bizon.engine.queue.queue import QUEUE_TERMINATION, QueueMessage
+from bizon.engine.queue.config import QUEUE_TERMINATION, QueueMessage
 
 from .config import KafkaConfigDetails
 

--- a/bizon/engine/queue/adapters/kafka/queue.py
+++ b/bizon/engine/queue/adapters/kafka/queue.py
@@ -5,7 +5,8 @@ from kafka import KafkaProducer
 from loguru import logger
 
 from bizon.destination.destination import AbstractDestination
-from bizon.engine.queue.queue import QUEUE_TERMINATION, AbstractQueue, QueueMessage
+from bizon.engine.queue.queue import AbstractQueue
+from bizon.engine.queue.config import QUEUE_TERMINATION, QueueMessage
 
 from .config import KafkaConfigDetails
 from .consumer import KafkaConsumer_

--- a/bizon/engine/queue/adapters/python_queue/consumer.py
+++ b/bizon/engine/queue/adapters/python_queue/consumer.py
@@ -1,7 +1,6 @@
 import multiprocessing
 import multiprocessing.synchronize
 import threading
-import traceback
 from typing import Union
 
 from loguru import logger
@@ -9,7 +8,8 @@ from loguru import logger
 from bizon.destination.destination import AbstractDestination
 from bizon.engine.pipeline.consumer import AbstractQueueConsumer
 from bizon.engine.pipeline.models import PipelineReturnStatus
-from bizon.engine.queue.queue import QUEUE_TERMINATION, AbstractQueue, QueueMessage
+from bizon.engine.queue.queue import AbstractQueue
+from bizon.engine.queue.config import QueueMessage
 from bizon.transform.transform import Transform
 
 from .config import PythonQueueConfig
@@ -23,46 +23,19 @@ class PythonQueueConsumer(AbstractQueueConsumer):
         self.queue = queue
 
     def run(self, stop_event: Union[threading.Event, multiprocessing.synchronize.Event]) -> PipelineReturnStatus:
+
         while True:
+
+            # Handle kill signal from the runner
             if stop_event.is_set():
                 logger.info("Stop event is set, closing consumer ...")
                 return PipelineReturnStatus.KILLED_BY_RUNNER
+
             # Retrieve the message from the queue
             queue_message: QueueMessage = self.queue.get()
 
-            # Apply the transformation
-            try:
-                df_source_records = self.transform.apply_transforms(df_source_records=queue_message.df_source_records)
-            except Exception as e:
-                logger.error(f"Error applying transformation: {e}")
-                logger.error(traceback.format_exc())
-                return PipelineReturnStatus.TRANSFORM_ERROR
+            status = self.process_queue_message(queue_message)
 
-            try:
-                if queue_message.signal == QUEUE_TERMINATION:
-                    logger.info("Received termination signal, waiting for destination to close gracefully ...")
-                    self.destination.write_records_and_update_cursor(
-                        df_source_records=df_source_records,
-                        iteration=queue_message.iteration,
-                        extracted_at=queue_message.extracted_at,
-                        pagination=queue_message.pagination,
-                        last_iteration=True,
-                    )
-                    break
-            except Exception as e:
-                logger.error(f"Error writing records to destination: {e}")
-                return PipelineReturnStatus.DESTINATION_ERROR
-
-            try:
-                self.destination.write_records_and_update_cursor(
-                    df_source_records=df_source_records,
-                    iteration=queue_message.iteration,
-                    extracted_at=queue_message.extracted_at,
-                    pagination=queue_message.pagination,
-                )
-            except Exception as e:
-                logger.error(f"Error writing records to destination: {e}")
-                return PipelineReturnStatus.DESTINATION_ERROR
-
-            self.queue.task_done()
-        return PipelineReturnStatus.SUCCESS
+            if status != PipelineReturnStatus.RUNNING:
+                self.queue.task_done()
+                return status

--- a/bizon/engine/queue/adapters/python_queue/queue.py
+++ b/bizon/engine/queue/adapters/python_queue/queue.py
@@ -6,11 +6,10 @@ from typing import Union
 from loguru import logger
 
 from bizon.destination.destination import AbstractDestination
+from bizon.engine.queue.config import QUEUE_TERMINATION, QueueMessage
 from bizon.engine.queue.queue import (
-    QUEUE_TERMINATION,
     AbstractQueue,
     AbstractQueueConsumer,
-    QueueMessage,
 )
 from bizon.source.models import SourceIteration
 from bizon.transform.transform import Transform

--- a/bizon/engine/queue/adapters/rabbitmq/consumer.py
+++ b/bizon/engine/queue/adapters/rabbitmq/consumer.py
@@ -3,8 +3,8 @@ import pika.connection
 from loguru import logger
 
 from bizon.destination.destination import AbstractDestination
+from bizon.engine.queue.config import QUEUE_TERMINATION
 from bizon.engine.queue.queue import (
-    QUEUE_TERMINATION,
     AbstractQueueConsumer,
     QueueMessage,
 )

--- a/bizon/engine/queue/adapters/rabbitmq/queue.py
+++ b/bizon/engine/queue/adapters/rabbitmq/queue.py
@@ -5,7 +5,8 @@ from loguru import logger
 
 from bizon.destination.destination import AbstractDestination
 from bizon.engine.pipeline.consumer import AbstractQueueConsumer
-from bizon.engine.queue.queue import QUEUE_TERMINATION, AbstractQueue, QueueMessage
+from bizon.engine.queue.queue import AbstractQueue
+from bizon.engine.queue.config import QUEUE_TERMINATION, QueueMessage
 
 from .config import RabbitMQConfigDetails
 from .consumer import RabbitMQConsumer

--- a/bizon/engine/queue/config.py
+++ b/bizon/engine/queue/config.py
@@ -1,8 +1,23 @@
 from abc import ABC
 from enum import Enum
+import polars as pl
+from datetime import datetime
+from typing import Optional
+from pytz import UTC
+
+from dataclasses import dataclass
 
 from pydantic import BaseModel, ConfigDict, Field
 
+QUEUE_TERMINATION = "TERMINATION"
+
+@dataclass
+class QueueMessage:
+    iteration: int
+    df_source_records: pl.DataFrame
+    extracted_at: datetime = datetime.now(tz=UTC)
+    pagination: Optional[dict] = None
+    signal: Optional[str] = None
 
 class QueueTypes(str, Enum):
     KAFKA = "kafka"

--- a/bizon/engine/queue/queue.py
+++ b/bizon/engine/queue/queue.py
@@ -12,18 +12,7 @@ from bizon.engine.pipeline.consumer import AbstractQueueConsumer
 from bizon.source.models import SourceIteration, source_record_schema
 from bizon.transform.transform import Transform
 
-from .config import AbastractQueueConfigDetails, AbstractQueueConfig, QueueTypes
-
-QUEUE_TERMINATION = "TERMINATION"
-
-
-@dataclass
-class QueueMessage:
-    iteration: int
-    df_source_records: pl.DataFrame
-    extracted_at: datetime = datetime.now(tz=UTC)
-    pagination: Optional[dict] = None
-    signal: Optional[str] = None
+from .config import AbastractQueueConfigDetails, AbstractQueueConfig, QueueTypes, QueueMessage
 
 
 class AbstractQueue(ABC):


### PR DESCRIPTION
- move `QueueMessage` processing logic in `AbstractConsumer` (rather than in adapter classes)