### PR TITLE
fix: revert streaming runner overlap to fix Kafka lag (v0.3.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.9] - 2026-04-07
+
+### Fixed
+- Reverted the streaming runner ThreadPoolExecutor changes from 0.3.8: the intended `consume(N+1)`/`write(N)` overlap was not actually achieved (the loop waited for the previous write before consuming the next batch), adding thread overhead and a one-iteration commit delay without throughput gain. Restored the simple sequential loop. The `max.poll.interval.ms=600000` Kafka consumer default introduced in 0.3.8 is retained as a safety net.
+
 ## [0.3.8] - 2026-04-03
 
 ### Fixed

--- a/bizon/engine/runner/adapters/streaming.py
+++ b/bizon/engine/runner/adapters/streaming.py
@@ -1,6 +1,5 @@
 import os
 import time
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from typing import List
 
@@ -112,35 +111,13 @@ class StreamingRunner(AbstractRunner):
 
         destination.buffer.buffer_size = 0  # force buffer to be flushed immediately
         iteration = 0
-        executor = ThreadPoolExecutor(max_workers=1)
-        pending_future = None
-        should_commit = False
 
         while True:
             if source.config.max_iterations and iteration > source.config.max_iterations:
-                # Wait for last write before exiting
-                if pending_future is not None:
-                    pending_future.result()
                 logger.info(f"Max iterations {source.config.max_iterations} reached, terminating stream ...")
                 break
 
             with monitor.trace(operation_name="bizon.stream.iteration"):
-                # === BACKPRESSURE: wait for previous write to finish ===
-                if pending_future is not None:
-                    pending_future.result()  # raises if write failed
-                    pending_future = None
-
-                    # Commit only after write confirmed successful
-                    if should_commit and os.getenv("ENVIRONMENT") == "production":
-                        try:
-                            source.commit()
-                        except Exception as e:
-                            logger.error(f"Error committing source: {e}")
-                            monitor.track_pipeline_status(PipelineReturnStatus.ERROR)
-                            return RunnerStatus(stream=PipelineReturnStatus.ERROR)
-                        should_commit = False
-
-                # === CONSUME (main thread - keeps heartbeats alive) ===
                 source_iteration = source.get()
 
                 destination_id_indexed_records = {}
@@ -158,8 +135,6 @@ class StreamingRunner(AbstractRunner):
                     else:
                         destination_id_indexed_records[record.destination_id] = [record]
 
-                # === PREPARE DATA (main thread - fast) ===
-                write_jobs = []
                 for destination_id, records in destination_id_indexed_records.items():
                     df_source_records = StreamingRunner.convert_source_records(records)
 
@@ -171,31 +146,30 @@ class StreamingRunner(AbstractRunner):
                     df_destination_records = StreamingRunner.convert_to_destination_records(
                         df_source_records, datetime.now(tz=UTC)
                     )
-                    write_jobs.append(
-                        (destination_id, df_destination_records, len(df_destination_records), dsm_headers)
+                    # Override destination_id
+                    destination.destination_id = destination_id
+                    destination.write_or_buffer_records(
+                        df_destination_records=df_destination_records,
+                        iteration=iteration,
+                        pagination=None,
+                    )
+                    monitor.track_records_synced(
+                        num_records=len(df_destination_records),
+                        destination_id=destination_id,
+                        extra_tags={"destination_id": destination_id},
+                        headers=dsm_headers,
                     )
 
-                # === SUBMIT WRITE (background thread - slow BigQuery writes) ===
-                def do_writes(jobs, iter_num):
-                    for dest_id, df_dest, num_records, headers in jobs:
-                        destination.destination_id = dest_id
-                        destination.write_or_buffer_records(
-                            df_destination_records=df_dest,
-                            iteration=iter_num,
-                            pagination=None,
-                        )
-                        monitor.track_records_synced(
-                            num_records=num_records,
-                            destination_id=dest_id,
-                            extra_tags={"destination_id": dest_id},
-                            headers=headers,
-                        )
+                if os.getenv("ENVIRONMENT") == "production":
+                    try:
+                        source.commit()
+                    except Exception as e:
+                        logger.error(f"Error committing source: {e}")
+                        monitor.track_pipeline_status(PipelineReturnStatus.ERROR)
+                        return RunnerStatus(stream=PipelineReturnStatus.ERROR)
 
-                pending_future = executor.submit(do_writes, write_jobs, iteration)
-                should_commit = True
                 iteration += 1
 
                 monitor.track_pipeline_status(PipelineReturnStatus.SUCCESS)
 
-        executor.shutdown(wait=True)
         return RunnerStatus(stream=PipelineReturnStatus.SUCCESS)  # return when max iterations is reached

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bizon"
-version = "0.3.8"
+version = "0.3.9"
 description = "Extract and load your data reliably from API Clients with native fault-tolerant and checkpointing mechanism."
 authors = [
     { name = "Antoine Balliet", email = "antoine.balliet@gmail.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -55,7 +55,7 @@ wheels = [
 
 [[package]]
 name = "bizon"
-version = "0.3.8"
+version = "0.3.9"
 source = { editable = "." }
 dependencies = [
     { name = "backoff" },


### PR DESCRIPTION
## Summary

Reverts the `ThreadPoolExecutor`-based streaming runner changes from #66 / v0.3.8. Bumps version to **0.3.9**. Keeps `max.poll.interval.ms=600000` from #66 — only the runner threading is reverted.

## Why

#66 was meant to overlap `consume(N+1)` with `write(N)` so Kafka polls stay alive during long BigQuery writes. The implementation does not actually overlap them — the loop body waits on `pending_future.result()` *before* calling `source.get()`:

```python
if pending_future is not None:
    pending_future.result()       # blocks for the entire previous BQ write
    ... commit ...
source_iteration = source.get()   # only consumes AFTER the wait
pending_future = executor.submit(do_writes, ...)
```

So consume(N+1) always runs after write(N) finishes — same wall-clock as the old sequential code, plus:
- ThreadPoolExecutor + closure allocation per iteration
- A one-iteration commit delay (offsets lag by one batch)
- Background thread mutating `destination.destination_id` (latent thread-safety footgun)
- `executor.shutdown(wait=True)` was unreachable in production (no `max_iterations`)

Combined with the "stabilization paradox" — #60 / #62 / #63 / #64 / #65 fixed several pipeline-crashing bugs in the same window, removing the crash-and-restart cycle that previously masked how slow steady-state throughput is — Kafka pipelines now run continuously at their (slow) baseline rate, so lag is finally visible.

This PR restores the simple sequential `consume → write → commit` loop that was in place pre-#66. It does **not** attempt to design proper consume-during-write overlap — that's a separate, larger conversation that wants real production write-time metrics first.

## What's kept from v0.3.8

- `max.poll.interval.ms=600000` (10 min) in `bizon/connectors/sources/kafka/src/config.py`. Still useful as a belt-and-braces safety net against rebalance during long writes, even though the runner no longer claims to overlap.

## What's reverted

- All threading-related code in `bizon/engine/runner/adapters/streaming.py` (`ThreadPoolExecutor` import, `pending_future` / `should_commit` locals, `do_writes` closure, the deferred-commit logic, the unreachable `executor.shutdown`).

## Files changed

- `bizon/engine/runner/adapters/streaming.py` — revert `run()` body to pre-#66 form (-66 / +25)
- `pyproject.toml` — `0.3.8` → `0.3.9`
- `uv.lock` — picks up the version bump
- `CHANGELOG.md` — `[0.3.9] - 2026-04-07` entry under `### Fixed`

## Test plan

- [x] `uv run ruff format` + `ruff check` on `streaming.py` — clean
- [x] `uv run pytest tests/connectors/sources/kafka/` — 27 passed
- [x] `uv run pytest tests/connectors/sources/kafka/test_kafka_decode.py` — 21 passed
- [x] Module import sanity check — no leftover `ThreadPoolExecutor` / `pending_future` / `should_commit` symbols in `StreamingRunner.run`
- [x] Diff verified to be the inverse of `9ad0ed5` for `streaming.py`
- [ ] Stage canary on one Kafka consumer group, watch `kafka_consumer_lag` for 30–60 min vs the v0.3.8 baseline before promoting

(Pre-existing test failures unrelated to this change: missing optional deps `pika`, `datadog`, `psycopg2`, and live BQ tests requiring credentials.)

## Out of scope (deliberate)

- Optimizing the per-row protobuf dict conversion from #62 (`destination.py:183`). It's correct and load-bearing for Debezium CDC; revisit only if metrics later prove it's the bottleneck.
- Changing `batch_size` / `consumer_timeout` defaults.
- Designing real consume-during-write overlap (heartbeat thread, partition pause/resume, etc.) — follow-up with metrics in hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)