### PR TITLE
fix: cache ensured tables in BigQuery streaming v2 to stop 403 storm

### DIFF
--- a/bizon/connectors/destinations/bigquery_streaming_v2/src/destination.py
+++ b/bizon/connectors/destinations/bigquery_streaming_v2/src/destination.py
@@ -75,6 +75,10 @@ class BigQueryStreamingV2Destination(AbstractDestination):
         self.bq_storage_client_options = ClientOptions(
             quota_project_id=self.project_id,
         )
+        # Cache of (temp_table_id, schema_fingerprint) pairs already ensured in this process.
+        # Prevents calling create_table on every flush, which otherwise hits BigQuery's
+        # per-table metadata quota (5 ops / 10s) and returns 403 rateLimitExceeded.
+        self._ensured_tables: set[tuple[str, int]] = set()
 
     @property
     def table_id(self) -> str:
@@ -275,32 +279,34 @@ class BigQueryStreamingV2Destination(AbstractDestination):
             raise
 
     def load_to_bigquery_via_streaming(self, df_destination_records: pl.DataFrame) -> str:
-        # Create table if it does not exist (use temp_table_id for staging)
+        # Ensure the staging table exists — but only once per (table, schema) in this process.
+        # Calling create_table on every flush otherwise hits BigQuery's per-table metadata
+        # quota (5 ops / 10s) and the API returns 403 rateLimitExceeded, which the google-cloud-bigquery
+        # SDK silently retries with exponential backoff.
         schema = self.get_bigquery_schema()
-        table = bigquery.Table(self.temp_table_id, schema=schema)
-        time_partitioning = TimePartitioning(
-            field=self.config.time_partitioning.field, type_=self.config.time_partitioning.type
-        )
-        table.time_partitioning = time_partitioning
+        schema_fingerprint = hash(tuple((f.name, f.field_type, f.mode) for f in schema))
+        cache_key = (self.temp_table_id, schema_fingerprint)
 
-        if self.clustering_keys and self.clustering_keys[self.destination_id]:
-            table.clustering_fields = self.clustering_keys[self.destination_id]
-        try:
-            table = self.bq_client.create_table(table)
-        except Conflict:
-            table = self.bq_client.get_table(self.temp_table_id)
-            # Compare and update schema if needed
-            existing_fields = {field.name: field for field in table.schema}
-            new_fields = {field.name: field for field in self.get_bigquery_schema()}
+        if cache_key not in self._ensured_tables:
+            table = bigquery.Table(self.temp_table_id, schema=schema)
+            table.time_partitioning = TimePartitioning(
+                field=self.config.time_partitioning.field, type_=self.config.time_partitioning.type
+            )
+            if self.clustering_keys and self.clustering_keys[self.destination_id]:
+                table.clustering_fields = self.clustering_keys[self.destination_id]
+            try:
+                self.bq_client.create_table(table)
+            except Conflict:
+                existing_table = self.bq_client.get_table(self.temp_table_id)
+                existing_fields = {field.name: field for field in existing_table.schema}
+                new_fields = {field.name: field for field in schema}
+                fields_to_add = [field for name, field in new_fields.items() if name not in existing_fields]
 
-            # Find fields that need to be added
-            fields_to_add = [field for name, field in new_fields.items() if name not in existing_fields]
-
-            if fields_to_add:
-                logger.warning(f"Adding new fields to table schema: {[field.name for field in fields_to_add]}")
-                updated_schema = table.schema + fields_to_add
-                table.schema = updated_schema
-                table = self.bq_client.update_table(table, ["schema"])
+                if fields_to_add:
+                    logger.warning(f"Adding new fields to table schema: {[field.name for field in fields_to_add]}")
+                    existing_table.schema = existing_table.schema + fields_to_add
+                    self.bq_client.update_table(existing_table, ["schema"])
+            self._ensured_tables.add(cache_key)
 
         # Create the stream (use temp_table_id for staging)
         temp_table_parts = self.temp_table_id.split(".")
@@ -439,6 +445,7 @@ class BigQueryStreamingV2Destination(AbstractDestination):
             ).result()
             logger.info(f"Deleting temp table {self.temp_table_id} ...")
             self.bq_client.delete_table(self.temp_table_id, not_found_ok=True)
+            self._ensured_tables = {k for k in self._ensured_tables if k[0] != self.temp_table_id}
             return True
 
         elif self.sync_metadata.sync_mode == SourceSyncModes.INCREMENTAL:
@@ -447,6 +454,7 @@ class BigQueryStreamingV2Destination(AbstractDestination):
             self.bq_client.query(f"INSERT INTO {self.table_id} SELECT * FROM {self.temp_table_id}").result()
             logger.info(f"Deleting incremental temp table {self.temp_table_id} ...")
             self.bq_client.delete_table(self.temp_table_id, not_found_ok=True)
+            self._ensured_tables = {k for k in self._ensured_tables if k[0] != self.temp_table_id}
             return True
 
         elif self.sync_metadata.sync_mode == SourceSyncModes.STREAM:


### PR DESCRIPTION
## Summary

- `BigQueryStreamingV2Destination.load_to_bigquery_via_streaming` called `self.bq_client.create_table(...)` on **every** flush, only catching `Conflict` (409). In the helpdesk CDC pipeline, one `bizon.stream.iteration` routes records to ~15 `destination_id`s, so every iteration issued ~15 sequential `POST /bigquery/v2/projects/{proj}/datasets/cdc/tables` requests — blowing past BigQuery's per-table metadata quota (5 ops / 10s) and returning **403 `rateLimitExceeded`** on every one.
- The pipeline kept producing data because `google-cloud-bigquery`'s `DEFAULT_RETRY` silently retries `rateLimitExceeded` with exponential backoff up to 10 minutes — so data flowed, but every iteration burned wall-clock in retries and every Datadog trace for `bizon-streaming` was red.
- Fix: cache `(temp_table_id, schema_fingerprint)` pairs on the destination instance. First call ensures (create or schema-reconcile), subsequent calls with the same schema skip the whole block. A genuine schema change (new column in `record_schemas`) produces a new fingerprint → runs the reconcile path exactly once.
- `finalize()` drops matching cache entries after `delete_table` in `FULL_REFRESH` and `INCREMENTAL` so a same-process re-run recreates the temp table.

No config changes, no migration, no new dependencies. Existing `Conflict` handling for schema drift is preserved. The SDK's built-in `rateLimitExceeded` retry remains as defense-in-depth.

## Files

- `bizon/connectors/destinations/bigquery_streaming_v2/src/destination.py`

## Test plan

- [x] `uv run ruff format` + `uv run ruff check` clean
- [x] `uv run pytest tests/connectors/destinations/bigquery_streaming_v2/test_bigquery_streaming_v2.py` — 4/4 pass
- [ ] Deploy to staging helpdesk CDC pipeline; confirm via Datadog: `service:bizon-streaming resource_name:"POST /bigquery/v2/projects/gorgias-pipeline-production/datasets/cdc/tables" @http.status_code:403` drops from ~15/iteration to 0 after warmup
- [ ] Confirm `bizon.stream.iteration` p50/p95 latency drops (SDK backoff no longer burning wall-clock on 403 retries)
- [ ] Sanity-check that schema drift (adding a column to `record_schemas`) still triggers the `Conflict` → `update_table` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)