### PR TITLE
fix: exit cleanly on Kafka commit ILLEGAL_GENERATION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.11] - 2026-04-17
+
+### Fixed
+- Kafka source now closes the consumer and exits when commit fails with `ILLEGAL_GENERATION` or `UNKNOWN_MEMBER_ID` (consumer evicted from the group). Previously these errors were silently swallowed, causing the evicted consumer to keep processing and duplicating writes with the new partition owner until the next rebalance. The pod now exits cleanly and Kubernetes restarts it with a fresh consumer that rejoins the group.
+
 ## [0.3.9] - 2026-04-07
 
 ### Fixed

--- a/bizon/connectors/sources/kafka/src/source.py
+++ b/bizon/connectors/sources/kafka/src/source.py
@@ -558,5 +558,19 @@ class KafkaSource(AbstractSource):
         try:
             self.consumer.commit(asynchronous=False)
         except CimplKafkaException as e:
+            error_code = e.args[0].code() if e.args else None
+            # Consumer has been evicted from the group. Further processing causes duplicate
+            # writes since the new partition owner is already processing these messages.
+            # Close gracefully and raise so the runner restarts the pod with a fresh consumer.
+            if error_code in (KafkaError.ILLEGAL_GENERATION, KafkaError.UNKNOWN_MEMBER_ID):
+                logger.error(
+                    f"Kafka commit rejected - consumer evicted from group (code={error_code}): {e}. "
+                    f"Closing consumer and exiting for clean restart."
+                )
+                try:
+                    self.consumer.close()
+                except Exception as close_err:
+                    logger.warning(f"Error closing consumer during eviction handling: {close_err}")
+                raise
             logger.error(f"Kafka exception occurred during commit: {e}")
             logger.info("Gracefully exiting without committing offsets due to Kafka exception")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bizon"
-version = "0.3.10"
+version = "0.3.11"
 description = "Extract and load your data reliably from API Clients with native fault-tolerant and checkpointing mechanism."
 authors = [
     { name = "Antoine Balliet", email = "antoine.balliet@gmail.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -55,7 +55,7 @@ wheels = [
 
 [[package]]
 name = "bizon"
-version = "0.3.9"
+version = "0.3.11"
 source = { editable = "." }
 dependencies = [
     { name = "backoff" },


### PR DESCRIPTION
## Summary
- When commit fails with `ILLEGAL_GENERATION` or `UNKNOWN_MEMBER_ID`, the consumer has been evicted from the group and its partitions are now owned by someone else
- Previously these errors were silently swallowed (`commit()` logged and returned), so the evicted consumer kept processing messages and duplicating writes against the new partition owner until the next rebalance
- Now the consumer is closed gracefully and the exception is re-raised, so the runner returns ERROR, the pod exits, and Kubernetes restarts it with a fresh consumer that rejoins the group cleanly
- Other Kafka commit errors (network, broker hiccups) keep the existing log-and-continue behavior

## Context
Seen repeatedly in production under v0.3.10:
```
ERROR Kafka exception occurred during commit: KafkaError{code=ILLEGAL_GENERATION,val=22,str="Commit failed: Broker: Specified group generation id is not valid"}
INFO  Gracefully exiting without committing offsets due to Kafka exception
```

## Test plan
- [x] `uv run pytest tests/connectors/sources/kafka/` — all 27 tests pass
- [x] `uv run ruff check && ruff format --check`
- [ ] Deploy to one pipeline, trigger a rebalance, confirm: pod exits, k8s restarts, new consumer joins group cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)