### PR TITLE
fix: use SOURCE_ERROR in streaming runner commit-failure path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Streaming runner crashed with a secondary `AttributeError: ERROR` when `source.commit()` raised, because `PipelineReturnStatus.ERROR` does not exist on the enum. The error branch now uses `PipelineReturnStatus.SOURCE_ERROR`, matching the convention used in `producer.py`, so the runner reports a clean Failure status instead of hiding the real commit error behind an enum lookup.
+
 ## [0.3.11] - 2026-04-17
 
 ### Fixed

--- a/bizon/engine/runner/adapters/streaming.py
+++ b/bizon/engine/runner/adapters/streaming.py
@@ -165,8 +165,8 @@ class StreamingRunner(AbstractRunner):
                         source.commit()
                     except Exception as e:
                         logger.error(f"Error committing source: {e}")
-                        monitor.track_pipeline_status(PipelineReturnStatus.ERROR)
-                        return RunnerStatus(stream=PipelineReturnStatus.ERROR)
+                        monitor.track_pipeline_status(PipelineReturnStatus.SOURCE_ERROR)
+                        return RunnerStatus(stream=PipelineReturnStatus.SOURCE_ERROR)
 
                 iteration += 1
 


### PR DESCRIPTION
## Summary
- `PipelineReturnStatus.ERROR` does not exist on the enum — when `source.commit()` raised in `StreamingRunner.run()`, the `except` branch crashed with a secondary `AttributeError: ERROR` instead of reporting failure cleanly.
- Swap both references in `bizon/engine/runner/adapters/streaming.py:168-169` to `PipelineReturnStatus.SOURCE_ERROR`, matching the convention already used in `bizon/engine/pipeline/producer.py`.

## Observed in production
Datadog traceback:
```
File ".../bizon/engine/runner/adapters/streaming.py", line 168, in run
  monitor.track_pipeline_status(PipelineReturnStatus.ERROR)
File ".../python3.11/enum.py", line 786, in __getattr__
  raise AttributeError(name) from None
AttributeError: ERROR
```

## Downstream impact (verified safe)
- `track_pipeline_status(...)`: value is interpolated into a statsd tag. `SOURCE_ERROR` is already emitted elsewhere (`producer.py`), so no new metric cardinality.
- `RunnerStatus(stream=SOURCE_ERROR)`: validates against `Optional[PipelineReturnStatus]`; `is_success` returns `False`; `to_string()` renders `"Pipeline finished with status Failure (Stream: source_error)"`.
- `bizon/cli/main.py:136` branches on `result.is_success` → failure path runs as intended (previously it never got there because of the crash).

## Test plan
- [x] `uv run ruff check bizon/engine/runner/adapters/streaming.py` — clean
- [x] `grep -rn "PipelineReturnStatus.ERROR\b" bizon/` returns no matches
- [x] Smoke test: `RunnerStatus(stream=PipelineReturnStatus.SOURCE_ERROR)` → `is_success=False`, `to_string()` renders correctly
- [ ] Merge and observe that streaming-runner commit failures now log `source_error` cleanly instead of `AttributeError: ERROR`

Version bump will follow in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)