### PR TITLE
chore: bump to 0.3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Streaming runner crashed with a secondary `AttributeError: ERROR` when `source.commit()` raised, because `PipelineReturnStatus.ERROR` does not exist on the enum. The error branch now uses `PipelineReturnStatus.SOURCE_ERROR`, matching the convention used in `producer.py`, so the runner reports a clean Failure status instead of hiding the real commit error behind an enum lookup.
+
 ## [0.3.11] - 2026-04-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.12] - 2026-04-17
+
 ### Fixed
 - Streaming runner crashed with a secondary `AttributeError: ERROR` when `source.commit()` raised, because `PipelineReturnStatus.ERROR` does not exist on the enum. The error branch now uses `PipelineReturnStatus.SOURCE_ERROR`, matching the convention used in `producer.py`, so the runner reports a clean Failure status instead of hiding the real commit error behind an enum lookup.
 

--- a/bizon/engine/runner/adapters/streaming.py
+++ b/bizon/engine/runner/adapters/streaming.py
@@ -165,8 +165,8 @@ class StreamingRunner(AbstractRunner):
                         source.commit()
                     except Exception as e:
                         logger.error(f"Error committing source: {e}")
-                        monitor.track_pipeline_status(PipelineReturnStatus.ERROR)
-                        return RunnerStatus(stream=PipelineReturnStatus.ERROR)
+                        monitor.track_pipeline_status(PipelineReturnStatus.SOURCE_ERROR)
+                        return RunnerStatus(stream=PipelineReturnStatus.SOURCE_ERROR)
 
                 iteration += 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bizon"
-version = "0.3.11"
+version = "0.3.12"
 description = "Extract and load your data reliably from API Clients with native fault-tolerant and checkpointing mechanism."
 authors = [
     { name = "Antoine Balliet", email = "antoine.balliet@gmail.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -55,7 +55,7 @@ wheels = [
 
 [[package]]
 name = "bizon"
-version = "0.3.11"
+version = "0.3.12"
 source = { editable = "." }
 dependencies = [
     { name = "backoff" },


### PR DESCRIPTION
## Summary
- Bumps bizon to 0.3.12.
- Moves the streaming-runner fix from `[Unreleased]` to the `0.3.12` section.

## Contents
- `PipelineReturnStatus.SOURCE_ERROR` fix in `StreamingRunner` (from #71).

## Test plan
- [ ] Merge #71 first (or let this PR auto-resolve once #71 is merged and rebase).
- [ ] After merge, tag `v0.3.12` to trigger PyPI publish + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)