### PR TITLE
fix: stop Kafka rebalance storm by not recreating consumer on ILLEGAL_GENERATION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.14] - 2026-04-17
+
+### Fixed
+- Kafka consumer rebalance storm: on `ILLEGAL_GENERATION` / `UNKNOWN_MEMBER_ID` during commit, the source no longer closes and recreates the Consumer. Closing sends `LeaveGroup`, which triggers a group-wide rebalance that invalidates every other consumer's generation, causing them to recreate too — a self-sustaining cascade observed in production with 16 replicas evicting in perfect millisecond-synchrony every ~35s. librdkafka's group state machine already handles the rejoin automatically on the next `consume()` call, preserving `member.id` and keeping the rest of the group undisturbed. Commit errors are now log-and-continue for this error class.
+
 ## [0.3.13] - 2026-04-17
 
 ### Changed

--- a/bizon/connectors/sources/kafka/src/source.py
+++ b/bizon/connectors/sources/kafka/src/source.py
@@ -554,26 +554,25 @@ class KafkaSource(AbstractSource):
             return self.read_topics_manually(pagination)
 
     def commit(self):
-        """Commit the offsets of the consumer"""
+        """Commit the offsets of the consumer.
+
+        On ILLEGAL_GENERATION / UNKNOWN_MEMBER_ID we log and return without closing
+        or recreating the consumer. librdkafka's consumer group state machine handles
+        the rejoin internally on the next consume() call, preserving member.id and
+        avoiding the LeaveGroup -> cluster-wide rebalance cascade that closing would
+        trigger. Uncommitted records may be reprocessed by the new partition owner
+        after the rejoin -- this is Bizon's standard at-least-once contract.
+        """
         try:
             self.consumer.commit(asynchronous=False)
         except CimplKafkaException as e:
             error_code = e.args[0].code() if e.args else None
             if error_code in (KafkaError.ILLEGAL_GENERATION, KafkaError.UNKNOWN_MEMBER_ID):
-                # Consumer was evicted from the group. Close it, recreate in place, and
-                # let the pipeline continue — next subscribe()/assign() rejoins the group.
-                # The uncommitted batch may be reprocessed by the new partition owner
-                # (Kafka at-least-once); downstream must tolerate duplicates.
                 logger.warning(
-                    f"Kafka commit rejected - consumer evicted from group (code={error_code}): {e}. "
-                    f"Recreating consumer in place; previous iteration's records may be "
+                    f"Kafka commit skipped - stale generation (code={error_code}): {e}. "
+                    f"librdkafka will rejoin on next consume(); uncommitted records may be "
                     f"reprocessed by the new partition owner (at-least-once)."
                 )
-                try:
-                    self.consumer.close()
-                except Exception as close_err:
-                    logger.warning(f"Error closing evicted consumer: {close_err}")
-                self.consumer = Consumer(self.config.consumer_config)
                 return
             logger.error(f"Kafka exception occurred during commit: {e}")
             logger.info("Gracefully exiting without committing offsets due to Kafka exception")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bizon"
-version = "0.3.13"
+version = "0.3.14"
 description = "Extract and load your data reliably from API Clients with native fault-tolerant and checkpointing mechanism."
 authors = [
     { name = "Antoine Balliet", email = "antoine.balliet@gmail.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -55,7 +55,7 @@ wheels = [
 
 [[package]]
 name = "bizon"
-version = "0.3.12"
+version = "0.3.14"
 source = { editable = "." }
 dependencies = [
     { name = "backoff" },


### PR DESCRIPTION
## Summary
Remove the `self.consumer.close()` + `self.consumer = Consumer(...)` calls from the `ILLEGAL_GENERATION` / `UNKNOWN_MEMBER_ID` branch of `KafkaSource.commit()`. Replace with a single log-and-return. librdkafka's consumer group state machine already handles rejoin automatically on the next `consume()` call.

## Root cause — production evidence
Observed on `conversations-events-bizon-streaming` (16 replicas):
- Every pod shows identical eviction counts (exactly 9 in 5min, 23-26 in 15min)
- Eviction timestamps match to the millisecond across pods (e.g. `11:52:49.880`, `11:54:04.053`, `11:55:06.167`)
- One rebalance event every ~35s, affecting all 16 pods simultaneously

This is a self-sustaining cascade:
1. Pod A commit fails with `ILLEGAL_GENERATION`
2. Pod A closes consumer → sends `LeaveGroup` → coordinator triggers group-wide rebalance
3. During rebalance, all other pods' generations become stale → their next commits also fail with `ILLEGAL_GENERATION`
4. All pods recreate → more `LeaveGroup`s → more rebalances
5. Fresh consumers rejoin as new dynamic members (no `group.instance.id`) → yet more rebalances

The storm never dies because each eviction creates more evictions.

## Why log-and-return is safe
- librdkafka preserves the Consumer object's internal state (member.id, metadata cache, connections) across `ILLEGAL_GENERATION` responses
- Next `consume()` automatically does `JoinGroup` / `SyncGroup` to rejoin with the same member.id
- No `LeaveGroup` is sent, so other pods' generations stay valid
- The recreate was never preventing duplicates — the uncommitted batch was already in BigQuery (at-least-once). Recreating only triggered the storm.

## Test plan
- [x] `uv run pytest tests/connectors/sources/kafka/` — 27 tests pass
- [x] `uv run ruff check && ruff format`
- [ ] Deploy to `conversations-events` pipeline (16 replicas). Within one rebalance cycle (~1 min), `grep "Kafka commit skipped"` should show a handful of transient events, not the sustained 9-per-5min pattern. `grep "Recreating consumer"` must be zero. Pod restart count must stay at 0.
- [ ] BigQuery `max(__event_timestamp)` keeps advancing without stalls

## Follow-ups (separate PRs)
- Add `partition.assignment.strategy: cooperative-sticky` (incremental rebalance — defense in depth)
- Opt-in `group.instance.id` from `HOSTNAME` env var for static membership
- Unit test mocking `consumer.commit` raising `CimplKafkaException(ILLEGAL_GENERATION)` and asserting `self.consumer` is the same instance afterward (regression guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)