### PR TITLE
fix: add Kafka static membership to stop rebalance storm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.15] - 2026-04-17
+
+### Fixed
+- Kafka rebalance storm, take 2: 0.3.14's "log-and-continue on ILLEGAL_GENERATION" was incorrect — librdkafka did not auto-rejoin after a commit-time generation failure, so the consumer stayed permanently in a stale generation and every subsequent commit failed indefinitely. Reverted to the 0.3.13 recreate-in-place behavior AND added **static membership** (KIP-345): `group.instance.id` is now derived from the `HOSTNAME` env var (auto-populated by Kubernetes to the pod name). With a stable instance ID, the close+recreate on `ILLEGAL_GENERATION` reconnects as the same member instead of joining as a new one, so the broker skips the full-group rebalance. This breaks the cascade that made one pod's eviction invalidate all 15 others. Users can override by setting `group.instance.id` explicitly in `consumer_config`.
+
 ## [0.3.14] - 2026-04-17
 
 ### Fixed

--- a/bizon/connectors/sources/kafka/src/source.py
+++ b/bizon/connectors/sources/kafka/src/source.py
@@ -1,3 +1,4 @@
+import os
 import re
 import traceback
 from collections.abc import Mapping
@@ -123,6 +124,21 @@ class KafkaSource(AbstractSource):
         # Set the bootstrap servers and group id
         self.config.consumer_config["group.id"] = self.config.group_id
         self.config.consumer_config["bootstrap.servers"] = self.config.bootstrap_servers
+
+        # Static group membership (KIP-345): when HOSTNAME is set (Kubernetes
+        # auto-populates it to the pod name), derive a stable group.instance.id
+        # so that brief disconnects and in-process consumer recreations (e.g.
+        # commit()'s recovery path on ILLEGAL_GENERATION) rejoin without
+        # triggering a group-wide rebalance. Users can override by setting
+        # group.instance.id explicitly in consumer_config.
+        if "group.instance.id" not in self.config.consumer_config:
+            hostname = os.environ.get("HOSTNAME")
+            if hostname:
+                self.config.consumer_config["group.instance.id"] = f"{self.config.group_id}-{hostname}"
+                logger.info(
+                    f"Kafka static membership enabled: "
+                    f"group.instance.id={self.config.consumer_config['group.instance.id']}"
+                )
 
         # Set the error callback
         self.config.consumer_config["error_cb"] = on_error
@@ -556,12 +572,12 @@ class KafkaSource(AbstractSource):
     def commit(self):
         """Commit the offsets of the consumer.
 
-        On ILLEGAL_GENERATION / UNKNOWN_MEMBER_ID we log and return without closing
-        or recreating the consumer. librdkafka's consumer group state machine handles
-        the rejoin internally on the next consume() call, preserving member.id and
-        avoiding the LeaveGroup -> cluster-wide rebalance cascade that closing would
-        trigger. Uncommitted records may be reprocessed by the new partition owner
-        after the rejoin -- this is Bizon's standard at-least-once contract.
+        On ILLEGAL_GENERATION / UNKNOWN_MEMBER_ID the consumer was evicted from the
+        group; close it, recreate in place, and let the next subscribe()/assign()
+        call rejoin. With static membership (group.instance.id) the broker recognizes
+        the reconnecting instance and avoids a group-wide rebalance cascade.
+        The uncommitted batch may be reprocessed by the new partition owner (Kafka
+        at-least-once); downstream must tolerate duplicates.
         """
         try:
             self.consumer.commit(asynchronous=False)
@@ -569,10 +585,15 @@ class KafkaSource(AbstractSource):
             error_code = e.args[0].code() if e.args else None
             if error_code in (KafkaError.ILLEGAL_GENERATION, KafkaError.UNKNOWN_MEMBER_ID):
                 logger.warning(
-                    f"Kafka commit skipped - stale generation (code={error_code}): {e}. "
-                    f"librdkafka will rejoin on next consume(); uncommitted records may be "
+                    f"Kafka commit rejected - consumer evicted from group (code={error_code}): {e}. "
+                    f"Recreating consumer in place; previous iteration's records may be "
                     f"reprocessed by the new partition owner (at-least-once)."
                 )
+                try:
+                    self.consumer.close()
+                except Exception as close_err:
+                    logger.warning(f"Error closing evicted consumer: {close_err}")
+                self.consumer = Consumer(self.config.consumer_config)
                 return
             logger.error(f"Kafka exception occurred during commit: {e}")
             logger.info("Gracefully exiting without committing offsets due to Kafka exception")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bizon"
-version = "0.3.14"
+version = "0.3.15"
 description = "Extract and load your data reliably from API Clients with native fault-tolerant and checkpointing mechanism."
 authors = [
     { name = "Antoine Balliet", email = "antoine.balliet@gmail.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -55,7 +55,7 @@ wheels = [
 
 [[package]]
 name = "bizon"
-version = "0.3.14"
+version = "0.3.15"
 source = { editable = "." }
 dependencies = [
     { name = "backoff" },


### PR DESCRIPTION
## Summary
- Restores the 0.3.13 recreate-in-place behavior in `commit()` (0.3.14's "just log and return" was wrong — librdkafka didn't auto-rejoin and commits kept failing indefinitely in production)
- Adds **static membership (KIP-345)**: `group.instance.id` auto-derived from the K8s-injected `HOSTNAME` env var. With a stable instance ID, the close+recreate reconnects as the same member, so the broker skips the full-group rebalance
- Users can override by setting `group.instance.id` explicitly in `consumer_config`

## Why this fixes the storm
Inspecting the consumer group via `AdminClient.describe_consumer_groups` while the storm was live:
```
state: PREPARING_REBALANCING
partition_assignor: cooperative-sticky
members: 34                    ← 16 pods but 34 members = 18 ghosts
group_instance_id: None        ← no static membership
```
Each pod's `consumer.close()` sent `LeaveGroup`, and each new `Consumer()` joined as a brand-new dynamic member (different `member.id`). With 16 pods recreating every ~40s and `session.timeout.ms=60s`, the group accumulated ghosts and stayed permanently in `PREPARING_REBALANCING`. Cooperative-sticky made each rebalance incremental but couldn't eliminate them — adding/removing group members always triggers one.

With static membership, the recreate reconnects to the existing slot → no `LeaveGroup`-driven rebalance → no cascade.

## Preemptible node interaction
- **In-process recreate** (the actual cause of the storm): static membership eliminates rebalance ✓
- **Pod eviction on preemption**: ~2 rebalances per pod replacement (same as before — new HOSTNAME = new instance), but these are rare and incremental under cooperative-sticky
- Net: more reliable, same preemption behavior

## Test plan
- [x] `uv run pytest tests/connectors/sources/kafka/` — 27 tests pass
- [x] `uv run ruff check && format`
- [ ] Deploy to **one low-replica pipeline first** (lower blast radius given prior incident). Verify:
  - Startup log shows `Kafka static membership enabled: group.instance.id=...`
  - `AdminClient` describe shows `group_instance_id` populated on the member
  - Normal processing continues, commits succeed
- [ ] Then deploy to `conversations-events` (16 replicas). Verify:
  - `members` count in the group equals live pod count (no ghost accumulation)
  - `Recreating consumer` log frequency drops dramatically (may still appear occasionally for legitimate rebalances, but not cascading)
  - BigQuery lag continues to drop

## Rollback
Single revert. Recreate logic is already there (from 0.3.13), static membership is purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)