### PR TITLE
fix: parse cursor pagination with json.loads on resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Cursor resume crashed with `ValueError: malformed node or string on line 1: <ast.Name object>` whenever the stored pagination dict contained a boolean or `None`. Pagination is written to the backend via `json.dumps`, but the producer was reading it back with `ast.literal_eval`, which can't parse JSON's `true` / `false` / `null` (they become `ast.Name` nodes). Connectors like Notion (`has_more`, `data_sources_loaded`) and Cycle (GraphQL `pageInfo.hasNextPage`) could never resume — the first retry would hit this error and the pod would exit with `BACKEND_ERROR`. Switched the producer to `json.loads`, matching the write path.
+
 ## [0.3.15] - 2026-04-17
 
 ### Fixed

--- a/bizon/engine/pipeline/producer.py
+++ b/bizon/engine/pipeline/producer.py
@@ -1,4 +1,4 @@
-import ast
+import json
 import multiprocessing
 import multiprocessing.synchronize
 import threading
@@ -58,7 +58,7 @@ class Producer:
                 total_records=job.total_records_to_fetch,
                 iteration=cursor_from_db.to_source_iteration + 1,
                 rows_fetched=self.backend.get_number_of_written_rows_for_job(job_id=job_id),
-                pagination=ast.literal_eval(cursor_from_db.pagination),
+                pagination=json.loads(cursor_from_db.pagination),
             )
         else:
             # Get the total number of records

--- a/tests/engine/test_producer_recovery.py
+++ b/tests/engine/test_producer_recovery.py
@@ -144,3 +144,43 @@ def test_e2e_dummy_to_file_recovery(file_destination, my_sqlite_backend, sqlite_
     assert cursor.source_name == "dummy"
     assert cursor.pagination == {"cursor": CURSOR}
     assert cursor.iteration == N_ITERATION + 1  # Should always be last iteration written to destination + 1
+
+
+def test_recovery_with_json_only_pagination_values(file_destination, my_sqlite_backend, sqlite_db_session):
+    """Regression test: pagination dicts with bool/None values must survive resume.
+
+    These are valid JSON but not Python literals, so parsing with ast.literal_eval
+    raised `ValueError: malformed node or string`. Stored via json.dumps, they
+    must be read back with json.loads.
+    """
+    N_ITERATION = 2
+    CURSOR = str(uuid4())
+    PAGINATION = {"cursor": CURSOR, "has_more": True, "next_page": None}
+
+    file_destination.buffer.buffer_size = 0
+    file_destination.write_or_buffer_records(
+        df_destination_records=df_destination_records,
+        iteration=N_ITERATION,
+        session=sqlite_db_session,
+        pagination=PAGINATION,
+    )
+    runner = RunnerFactory.create_from_config_dict(yaml.safe_load(BIZON_CONFIG_DUMMY_TO_FILE))
+
+    bizon_config = runner.bizon_config
+    config = runner.config
+    kwargs = runner.get_kwargs()
+    source = AbstractRunner.get_source(bizon_config=bizon_config, config=config)
+    queue = AbstractRunner.get_queue(bizon_config=bizon_config, **kwargs)
+
+    producer = AbstractRunner.get_producer(
+        bizon_config=bizon_config,
+        source=source,
+        queue=queue,
+        backend=my_sqlite_backend,
+    )
+
+    cursor = producer.get_or_create_cursor(job_id=file_destination.sync_metadata.job_id, session=sqlite_db_session)
+
+    assert cursor is not None
+    assert cursor.pagination == PAGINATION
+    assert cursor.iteration == N_ITERATION + 1


### PR DESCRIPTION
## Summary

On resume, the producer crashed with:

```
ValueError: malformed node or string on line 1: <ast.Name object at 0x...>
  File ".../bizon/engine/pipeline/producer.py", line 61, in get_or_create_cursor
    pagination=ast.literal_eval(cursor_from_db.pagination),
```

**Root cause:** pagination is written as JSON (`json.dumps` at `backend/adapters/sqlalchemy/backend.py:296` and `:398`), but read back with `ast.literal_eval`. `ast.literal_eval` parses Python literal syntax; JSON's `true` / `false` / `null` become `ast.Name` nodes and raise. Any pagination dict containing a bool or `None` — e.g. `{"has_more": true, "cursor": null}` — was unrecoverable. The pipeline exited with `BACKEND_ERROR` on every retry.

**Impact:** Connectors that currently break on resume
- **Notion** — `has_more`, `data_sources_loaded: True`, `next_cursor` can be `None`
- **Cycle** — passes through GraphQL `pageInfo` which includes `hasNextPage` (bool)

Other connectors (Dummy, GSheets, Kafka, PokeAPI, SanaAI, Periscope) only store strings/lists/ints and worked by accident.

## Change

- `bizon/engine/pipeline/producer.py` — swap `ast.literal_eval` → `json.loads`, matching the write path. No migration needed: `json.dumps` has been the writer since the initial commit.
- `tests/engine/test_producer_recovery.py` — new regression test `test_recovery_with_json_only_pagination_values` persisting `{"cursor": ..., "has_more": True, "next_page": None}` and asserting recovery. Fails on `main` with the exact bug-report stacktrace.

## Test plan

- [x] `uv run pytest tests/engine/test_producer_recovery.py -v` — both tests pass
- [x] `uv run pytest tests/engine/ --ignore=tests/engine/test_parse_yaml.py --ignore=tests/engine/queue/test_queue_factory.py` — 34 passed; remaining failures are unrelated missing-extras (postgres/bigquery/kafka)
- [x] `make format` — clean
- [ ] Verify a Notion or Cycle pipeline resumes cleanly in staging after this ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)