### PR TITLE
chore: bump version to 0.3.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16] - 2026-04-20
+
 ### Fixed
 - Cursor resume crashed with `ValueError: malformed node or string on line 1: <ast.Name object>` whenever the stored pagination dict contained a boolean or `None`. Pagination is written to the backend via `json.dumps`, but the producer was reading it back with `ast.literal_eval`, which can't parse JSON's `true` / `false` / `null` (they become `ast.Name` nodes). Connectors like Notion (`has_more`, `data_sources_loaded`) and Cycle (GraphQL `pageInfo.hasNextPage`) could never resume — the first retry would hit this error and the pod would exit with `BACKEND_ERROR`. Switched the producer to `json.loads`, matching the write path.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bizon"
-version = "0.3.15"
+version = "0.3.16"
 description = "Extract and load your data reliably from API Clients with native fault-tolerant and checkpointing mechanism."
 authors = [
     { name = "Antoine Balliet", email = "antoine.balliet@gmail.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -55,7 +55,7 @@ wheels = [
 
 [[package]]
 name = "bizon"
-version = "0.3.15"
+version = "0.3.16"
 source = { editable = "." }
 dependencies = [
     { name = "backoff" },


### PR DESCRIPTION
## Summary

- Bumps version `0.3.15` → `0.3.16`
- Moves the `[Unreleased]` changelog entry to the new `[0.3.16] - 2026-04-20` section
- Releases the cursor-resume fix from #76 (`json.loads` instead of `ast.literal_eval` when rehydrating pagination)

Tag `v0.3.16` can be pushed after merge to trigger the PyPI/GitHub release workflow.

## Test plan

- [ ] Merge and push `v0.3.16` tag
- [ ] Verify the publish workflow succeeds and the release notes pick up the 0.3.16 changelog section

🤖 Generated with [Claude Code](https://claude.com/claude-code)