### PR TITLE
feat(bigquery): prefix auto-generated tables with _bizon_ (backwards compatible)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- BigQuery destinations (`bigquery`, `bigquery_streaming`, `bigquery_streaming_v2`) now prefix auto-generated table names with `_bizon_` so bizon-managed tables are clearly namespaced in shared datasets. This is **backwards compatible**: when no explicit `destination_id` is set, the destination first checks whether the legacy unprefixed table (`{source}_{stream}`) already exists — if it does, it keeps writing to it untouched, so existing pipelines are never disrupted; only brand-new tables get the `_bizon_` prefix. The lookup result is cached (one `get_table` call per run) and any non-`NotFound` error falls back to the legacy name. An explicit `destination_id` is never prefixed. Temp/staging tables (`_temp` / `_incremental`) inherit the resolved name. The prefix is configurable per destination via the new `table_prefix` field (default `_bizon_`; set to `""` to disable).
+
 ## [0.3.16] - 2026-04-20
 
 ### Fixed

--- a/bizon/connectors/destinations/bigquery/src/config.py
+++ b/bizon/connectors/destinations/bigquery/src/config.py
@@ -11,6 +11,8 @@ from bizon.destination.config import (
     DestinationTypes,
 )
 
+from .table_naming import BIZON_TABLE_PREFIX
+
 
 class GCSBufferFormat(str, Enum):
     PARQUET = "parquet"
@@ -115,6 +117,12 @@ class BigQueryConfigDetails(AbstractDestinationDetailsConfig):
     # Schema for unnesting
     record_schemas: Optional[list[BigQueryRecordSchemaConfig]] = Field(
         default=None, description="Schema for the records. Required if unnest is set to true."
+    )
+
+    table_prefix: str = Field(
+        default=BIZON_TABLE_PREFIX,
+        description="Prefix applied to auto-generated table names (when destination_id is not set). "
+        "An existing legacy (unprefixed) table is reused if present. Set to '' to disable.",
     )
 
     authentication: Optional[BigQueryAuthentication] = None

--- a/bizon/connectors/destinations/bigquery/src/destination.py
+++ b/bizon/connectors/destinations/bigquery/src/destination.py
@@ -19,6 +19,7 @@ from bizon.source.config import SourceSyncModes
 from bizon.source.source import AbstractSourceCallback
 
 from .config import BigQueryColumn, BigQueryConfigDetails
+from .table_naming import resolve_default_table_id
 
 
 class BigQueryDestination(AbstractDestination):
@@ -47,11 +48,20 @@ class BigQueryDestination(AbstractDestination):
         self.buffer_format = config.gcs_buffer_format
         self.dataset_id = config.dataset_id
         self.dataset_location = config.dataset_location
+        self._resolved_default_table_id: str | None = None
 
     @property
     def table_id(self) -> str:
-        tabled_id = self.destination_id or f"{self.sync_metadata.source_name}_{self.sync_metadata.stream_name}"
-        return f"{self.project_id}.{self.dataset_id}.{tabled_id}"
+        # Explicit destination_id (bare table name) is the user's choice -> never prefixed.
+        if self.destination_id:
+            return f"{self.project_id}.{self.dataset_id}.{self.destination_id}"
+        # Auto-generated name: resolve once (reuses a legacy table if present, else `_bizon_` prefix).
+        if self._resolved_default_table_id is None:
+            base_name = f"{self.sync_metadata.source_name}_{self.sync_metadata.stream_name}"
+            self._resolved_default_table_id = resolve_default_table_id(
+                self.bq_client, self.project_id, self.dataset_id, base_name, self.config.table_prefix
+            )
+        return self._resolved_default_table_id
 
     @property
     def temp_table_id(self) -> str:

--- a/bizon/connectors/destinations/bigquery/src/table_naming.py
+++ b/bizon/connectors/destinations/bigquery/src/table_naming.py
@@ -1,0 +1,49 @@
+from google.api_core.exceptions import NotFound
+from google.cloud import bigquery
+from loguru import logger
+
+BIZON_TABLE_PREFIX = "_bizon_"
+
+
+def resolve_default_table_id(
+    bq_client: bigquery.Client,
+    project_id: str,
+    dataset_id: str,
+    base_name: str,
+    prefix: str = BIZON_TABLE_PREFIX,
+) -> str:
+    """Resolve the fully-qualified table id for an AUTO-GENERATED name.
+
+    Reuses an existing legacy (unprefixed) table if one is already present, so existing
+    pipelines keep writing to their current table. Brand-new pipelines get the ``prefix``
+    (``_bizon_`` by default) so bizon-managed tables are clearly namespaced.
+
+    Args:
+        bq_client: BigQuery client used to check for an existing legacy table.
+        project_id: BigQuery project id.
+        dataset_id: BigQuery dataset id.
+        base_name: Auto-generated table name, e.g. ``f"{source_name}_{stream_name}"``.
+        prefix: Prefix applied to brand-new tables. Empty string disables prefixing.
+
+    Returns:
+        Fully-qualified ``project.dataset.table`` id.
+    """
+    legacy_id = f"{project_id}.{dataset_id}.{base_name}"
+
+    # No prefix configured -> keep the historical behavior.
+    if not prefix:
+        return legacy_id
+
+    prefixed_id = f"{project_id}.{dataset_id}.{prefix}{base_name}"
+
+    try:
+        bq_client.get_table(legacy_id)
+        logger.info(f"Reusing existing legacy table {legacy_id} (skipping '{prefix}' prefix)")
+        return legacy_id
+    except NotFound:
+        return prefixed_id
+    except Exception as e:
+        # Any other error (e.g. permissions / transient): fall back to the legacy name,
+        # which is exactly the previous behavior, so we never regress an existing run.
+        logger.warning(f"Could not check existence of {legacy_id} ({e}); falling back to legacy name")
+        return legacy_id

--- a/bizon/connectors/destinations/bigquery_streaming/src/config.py
+++ b/bizon/connectors/destinations/bigquery_streaming/src/config.py
@@ -4,6 +4,7 @@ from typing import Literal, Optional
 from pydantic import BaseModel, Field
 
 from bizon.connectors.destinations.bigquery.src.config import BigQueryRecordSchemaConfig
+from bizon.connectors.destinations.bigquery.src.table_naming import BIZON_TABLE_PREFIX
 from bizon.destination.config import (
     AbstractDestinationConfig,
     AbstractDestinationDetailsConfig,
@@ -48,6 +49,11 @@ class BigQueryStreamingConfigDetails(AbstractDestinationDetailsConfig):
     )
     record_schemas: Optional[list[BigQueryRecordSchemaConfig]] = Field(
         default=None, description="Schema for the records. Required if unnest is set to true."
+    )
+    table_prefix: str = Field(
+        default=BIZON_TABLE_PREFIX,
+        description="Prefix applied to auto-generated table names (when destination_id is not set). "
+        "An existing legacy (unprefixed) table is reused if present. Set to '' to disable.",
     )
 
 

--- a/bizon/connectors/destinations/bigquery_streaming/src/destination.py
+++ b/bizon/connectors/destinations/bigquery_streaming/src/destination.py
@@ -33,6 +33,7 @@ from bizon.connectors.destinations.bigquery.src.config import (
     BigQueryColumnMode,
     BigQueryColumnType,
 )
+from bizon.connectors.destinations.bigquery.src.table_naming import resolve_default_table_id
 from bizon.destination.destination import AbstractDestination
 from bizon.engine.backend.backend import AbstractBackend
 from bizon.monitoring.monitor import AbstractMonitor
@@ -69,11 +70,20 @@ class BigQueryStreamingDestination(AbstractDestination):
         self.dataset_id = config.dataset_id
         self.dataset_location = config.dataset_location
         self.bq_max_rows_per_request = config.bq_max_rows_per_request
+        self._resolved_default_table_id: str | None = None
 
     @property
     def table_id(self) -> str:
-        tabled_id = f"{self.sync_metadata.source_name}_{self.sync_metadata.stream_name}"
-        return self.destination_id or f"{self.project_id}.{self.dataset_id}.{tabled_id}"
+        # Explicit destination_id (full project.dataset.table path) is the user's choice -> never prefixed.
+        if self.destination_id:
+            return self.destination_id
+        # Auto-generated name: resolve once (reuses a legacy table if present, else `_bizon_` prefix).
+        if self._resolved_default_table_id is None:
+            base_name = f"{self.sync_metadata.source_name}_{self.sync_metadata.stream_name}"
+            self._resolved_default_table_id = resolve_default_table_id(
+                self.bq_client, self.project_id, self.dataset_id, base_name, self.config.table_prefix
+            )
+        return self._resolved_default_table_id
 
     def get_bigquery_schema(self) -> List[bigquery.SchemaField]:
         if self.config.unnest:

--- a/bizon/connectors/destinations/bigquery_streaming_v2/src/config.py
+++ b/bizon/connectors/destinations/bigquery_streaming_v2/src/config.py
@@ -4,6 +4,7 @@ from typing import Literal, Optional
 from pydantic import BaseModel, Field
 
 from bizon.connectors.destinations.bigquery.src.config import BigQueryRecordSchemaConfig
+from bizon.connectors.destinations.bigquery.src.table_naming import BIZON_TABLE_PREFIX
 from bizon.destination.config import (
     AbstractDestinationConfig,
     AbstractDestinationDetailsConfig,
@@ -48,6 +49,11 @@ class BigQueryStreamingV2ConfigDetails(AbstractDestinationDetailsConfig):
     )
     record_schemas: Optional[list[BigQueryRecordSchemaConfig]] = Field(
         default=None, description="Schema for the records. Required if unnest is set to true."
+    )
+    table_prefix: str = Field(
+        default=BIZON_TABLE_PREFIX,
+        description="Prefix applied to auto-generated table names (when destination_id is not set). "
+        "An existing legacy (unprefixed) table is reused if present. Set to '' to disable.",
     )
 
 

--- a/bizon/connectors/destinations/bigquery_streaming_v2/src/destination.py
+++ b/bizon/connectors/destinations/bigquery_streaming_v2/src/destination.py
@@ -35,6 +35,7 @@ from tenacity import (
 )
 
 from bizon.common.models import SyncMetadata
+from bizon.connectors.destinations.bigquery.src.table_naming import resolve_default_table_id
 from bizon.destination.destination import AbstractDestination
 from bizon.engine.backend.backend import AbstractBackend
 from bizon.monitoring.monitor import AbstractMonitor
@@ -79,11 +80,20 @@ class BigQueryStreamingV2Destination(AbstractDestination):
         # Prevents calling create_table on every flush, which otherwise hits BigQuery's
         # per-table metadata quota (5 ops / 10s) and returns 403 rateLimitExceeded.
         self._ensured_tables: set[tuple[str, int]] = set()
+        self._resolved_default_table_id: str | None = None
 
     @property
     def table_id(self) -> str:
-        tabled_id = f"{self.sync_metadata.source_name}_{self.sync_metadata.stream_name}"
-        return self.destination_id or f"{self.project_id}.{self.dataset_id}.{tabled_id}"
+        # Explicit destination_id (full project.dataset.table path) is the user's choice -> never prefixed.
+        if self.destination_id:
+            return self.destination_id
+        # Auto-generated name: resolve once (reuses a legacy table if present, else `_bizon_` prefix).
+        if self._resolved_default_table_id is None:
+            base_name = f"{self.sync_metadata.source_name}_{self.sync_metadata.stream_name}"
+            self._resolved_default_table_id = resolve_default_table_id(
+                self.bq_client, self.project_id, self.dataset_id, base_name, self.config.table_prefix
+            )
+        return self._resolved_default_table_id
 
     @property
     def temp_table_id(self) -> str:

--- a/tests/connectors/destinations/bigquery/test_table_naming.py
+++ b/tests/connectors/destinations/bigquery/test_table_naming.py
@@ -1,0 +1,195 @@
+"""Unit tests for the `_bizon_` table-prefix resolution (CI-safe, no live BigQuery)."""
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+from google.api_core.exceptions import Forbidden, NotFound
+
+from bizon.common.models import SyncMetadata
+from bizon.connectors.destinations.bigquery.src.config import (
+    BigQueryConfig,
+    BigQueryConfigDetails,
+)
+from bizon.connectors.destinations.bigquery.src.destination import BigQueryDestination
+from bizon.connectors.destinations.bigquery.src.table_naming import (
+    BIZON_TABLE_PREFIX,
+    resolve_default_table_id,
+)
+from bizon.connectors.destinations.bigquery_streaming.src.config import BigQueryStreamingConfigDetails
+from bizon.connectors.destinations.bigquery_streaming.src.destination import BigQueryStreamingDestination
+from bizon.connectors.destinations.bigquery_streaming_v2.src.config import BigQueryStreamingV2ConfigDetails
+from bizon.connectors.destinations.bigquery_streaming_v2.src.destination import BigQueryStreamingV2Destination
+from bizon.destination.config import DestinationTypes
+
+PROJECT = "my_project"
+DATASET = "bizon_test"
+SOURCE = "cookie"
+STREAM = "test"
+BASE_NAME = f"{SOURCE}_{STREAM}"
+LEGACY_ID = f"{PROJECT}.{DATASET}.{BASE_NAME}"
+PREFIXED_ID = f"{PROJECT}.{DATASET}.{BIZON_TABLE_PREFIX}{BASE_NAME}"
+
+
+def make_bq_client(get_table_side_effect):
+    client = MagicMock()
+    client.get_table.side_effect = get_table_side_effect
+    return client
+
+
+# ---------------------------------------------------------------------------
+# resolve_default_table_id: the core logic
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_reuses_existing_legacy_table():
+    """An existing unprefixed table is reused (backwards compatibility)."""
+    client = make_bq_client(get_table_side_effect=lambda table_id: MagicMock())
+    resolved = resolve_default_table_id(client, PROJECT, DATASET, BASE_NAME)
+    assert resolved == LEGACY_ID
+    client.get_table.assert_called_once_with(LEGACY_ID)
+
+
+def test_resolve_prefixes_brand_new_table():
+    """When no legacy table exists, the `_bizon_` prefix is applied."""
+    client = make_bq_client(get_table_side_effect=NotFound("missing"))
+    resolved = resolve_default_table_id(client, PROJECT, DATASET, BASE_NAME)
+    assert resolved == PREFIXED_ID
+
+
+def test_resolve_empty_prefix_disables_prefixing():
+    """An empty prefix keeps the historical (unprefixed) name and skips the lookup."""
+    client = make_bq_client(get_table_side_effect=NotFound("missing"))
+    resolved = resolve_default_table_id(client, PROJECT, DATASET, BASE_NAME, prefix="")
+    assert resolved == LEGACY_ID
+    client.get_table.assert_not_called()
+
+
+def test_resolve_non_notfound_error_falls_back_to_legacy():
+    """Any non-NotFound error falls back to the legacy name (== current behavior, no regression)."""
+    client = make_bq_client(get_table_side_effect=Forbidden("no permission"))
+    resolved = resolve_default_table_id(client, PROJECT, DATASET, BASE_NAME)
+    assert resolved == LEGACY_ID
+
+
+def test_resolve_custom_prefix():
+    client = make_bq_client(get_table_side_effect=NotFound("missing"))
+    resolved = resolve_default_table_id(client, PROJECT, DATASET, BASE_NAME, prefix="staging_")
+    assert resolved == f"{PROJECT}.{DATASET}.staging_{BASE_NAME}"
+
+
+# ---------------------------------------------------------------------------
+# table_id wiring across the three destination variants
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sync_metadata() -> SyncMetadata:
+    return SyncMetadata(
+        name="gcs_loading",
+        job_id="rfou98C9DJH",
+        source_name=SOURCE,
+        stream_name=STREAM,
+        destination_name="bigquery",
+        destination_alias="bigquery",
+        sync_mode="full_refresh",
+    )
+
+
+@contextmanager
+def build_destination(variant: str, sync_metadata: SyncMetadata, get_table_side_effect, **config_overrides):
+    """Construct a destination with all google clients patched, then swap in a controllable bq_client."""
+    mock_args = dict(
+        sync_metadata=sync_metadata,
+        backend=MagicMock(),
+        source_callback=MagicMock(),
+        monitor=MagicMock(),
+    )
+
+    if variant == "bigquery":
+        module = "bizon.connectors.destinations.bigquery.src.destination"
+        config = BigQueryConfigDetails(
+            project_id=PROJECT, dataset_id=DATASET, gcs_buffer_bucket="bizon-buffer", **config_overrides
+        )
+        with patch(f"{module}.bigquery.Client"), patch(f"{module}.storage.Client"):
+            dest = BigQueryDestination(config=config, **mock_args)
+    elif variant == "streaming":
+        module = "bizon.connectors.destinations.bigquery_streaming.src.destination"
+        config = BigQueryStreamingConfigDetails(project_id=PROJECT, dataset_id=DATASET, **config_overrides)
+        with patch(f"{module}.bigquery.Client"), patch(f"{module}.bigquery_storage_v1.BigQueryWriteClient"):
+            dest = BigQueryStreamingDestination(config=config, **mock_args)
+    elif variant == "streaming_v2":
+        module = "bizon.connectors.destinations.bigquery_streaming_v2.src.destination"
+        config = BigQueryStreamingV2ConfigDetails(project_id=PROJECT, dataset_id=DATASET, **config_overrides)
+        with patch(f"{module}.bigquery.Client"):
+            dest = BigQueryStreamingV2Destination(config=config, **mock_args)
+    else:
+        raise ValueError(variant)
+
+    dest.bq_client = make_bq_client(get_table_side_effect)
+    yield dest
+
+
+ALL_VARIANTS = ["bigquery", "streaming", "streaming_v2"]
+
+
+@pytest.mark.parametrize("variant", ALL_VARIANTS)
+def test_table_id_reuses_legacy(variant, sync_metadata):
+    with build_destination(variant, sync_metadata, get_table_side_effect=lambda t: MagicMock()) as dest:
+        assert dest.table_id == LEGACY_ID
+
+
+@pytest.mark.parametrize("variant", ALL_VARIANTS)
+def test_table_id_prefixes_new(variant, sync_metadata):
+    with build_destination(variant, sync_metadata, get_table_side_effect=NotFound("missing")) as dest:
+        assert dest.table_id == PREFIXED_ID
+
+
+@pytest.mark.parametrize("variant", ALL_VARIANTS)
+def test_table_id_resolution_is_cached(variant, sync_metadata):
+    with build_destination(variant, sync_metadata, get_table_side_effect=NotFound("missing")) as dest:
+        _ = dest.table_id
+        _ = dest.table_id
+        _ = dest.table_id
+        assert dest.bq_client.get_table.call_count == 1
+
+
+@pytest.mark.parametrize("variant", ALL_VARIANTS)
+def test_table_id_empty_prefix_keeps_legacy(variant, sync_metadata):
+    with build_destination(variant, sync_metadata, get_table_side_effect=NotFound("missing"), table_prefix="") as dest:
+        assert dest.table_id == LEGACY_ID
+        dest.bq_client.get_table.assert_not_called()
+
+
+def test_table_id_explicit_destination_id_bigquery(sync_metadata):
+    """bigquery: destination_id is a bare name, wrapped with project.dataset, never prefixed or looked up."""
+    with build_destination(
+        "bigquery", sync_metadata, get_table_side_effect=NotFound("missing"), destination_id="custom_table"
+    ) as dest:
+        assert dest.table_id == f"{PROJECT}.{DATASET}.custom_table"
+        dest.bq_client.get_table.assert_not_called()
+
+
+@pytest.mark.parametrize("variant", ["streaming", "streaming_v2"])
+def test_table_id_explicit_destination_id_streaming(variant, sync_metadata):
+    """streaming variants: destination_id is a full path, used as-is, never prefixed or looked up."""
+    full_path = "other_project.other_dataset.custom_table"
+    with build_destination(
+        variant, sync_metadata, get_table_side_effect=NotFound("missing"), destination_id=full_path
+    ) as dest:
+        assert dest.table_id == full_path
+        dest.bq_client.get_table.assert_not_called()
+
+
+def test_temp_table_inherits_resolved_name(sync_metadata):
+    """Temp/staging table names are derived from the resolved (prefixed) table_id."""
+    with build_destination("bigquery", sync_metadata, get_table_side_effect=NotFound("missing")) as dest:
+        assert dest.temp_table_id == f"{PREFIXED_ID}_temp"
+
+
+def test_default_config_prefix_is_bizon():
+    config = BigQueryConfig(
+        name=DestinationTypes.BIGQUERY,
+        config=BigQueryConfigDetails(project_id=PROJECT, dataset_id=DATASET, gcs_buffer_bucket="bizon-buffer"),
+    )
+    assert config.config.table_prefix == "_bizon_"


### PR DESCRIPTION
## What

BigQuery destinations now namespace **auto-generated** table names with a `_bizon_` prefix, so bizon-managed tables are clearly identifiable in shared datasets. Covers all three variants: `bigquery`, `bigquery_streaming`, `bigquery_streaming_v2`.

## Why it's safe for existing runs

The hard requirement was **not breaking current pipelines**. Naively changing the default name would orphan every existing auto-named table (full-refresh consumers break; incremental re-syncs from scratch). So this uses auto-detection:

- New helper `resolve_default_table_id()` (`bizon/connectors/destinations/bigquery/src/table_naming.py`):
  - When no explicit `destination_id` is set, it checks whether the **legacy unprefixed table** (`{source}_{stream}`) already exists via `get_table`.
  - **Exists** → keeps the legacy name (existing pipelines untouched).
  - **`NotFound`** → uses the `_bizon_`-prefixed name (brand-new pipelines only).
  - **Any other error** (perms/transient) → falls back to the legacy name = current behavior, so it can never regress a running pipeline.
- The result is **cached** (one `get_table` call per run).
- Each variant's `table_id` quirk is respected: `bigquery` treats `destination_id` as a bare name; the streaming variants as a full path.
- An explicit `destination_id` (including the dynamic unnest path) is **never** prefixed.
- Temp/staging tables (`_temp` / `_incremental`) inherit the resolved name automatically.
- New `table_prefix` config field (default `_bizon_`) on all three configs gives an instant opt-out: set to `""`.

### Backwards-compatibility matrix

| Scenario | Behavior |
|---|---|
| Existing auto-named table present | Reused as-is — **no disruption** |
| Brand-new pipeline | Creates `_bizon_…` |
| Explicit `destination_id` | Unchanged, never prefixed |
| `get_table` errors | Falls back to legacy name |
| `table_prefix: ""` | Always legacy name |

## Tests

- 22 new CI-safe unit tests (`tests/connectors/destinations/bigquery/test_table_naming.py`) mocking `get_table` — cover reuse / prefix / cache / opt-out / explicit-id / temp-inheritance across all three variants. All pass.
- Verified against a `git stash` baseline that the pre-existing live-BigQuery test failures (placeholder-project streaming/`_live` tests, `SyncMetadata` schema drift) fail identically on `main` — this change adds zero new failures.
- `ruff` format + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)